### PR TITLE
Include ldap3 in Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,6 @@ werkzeug==0.16.1
 # Install the dependencies of the bin/bundle-extensions script here.
 # It has its own requirements file to simplify the frontend client build process
 -r requirements_bundles.txt
-# Uncomment the requirement for ldap3 if using ldap.
-# It is not included by default because of the GPL license conflict.
-# ldap3==2.2.4
+# Include ldap3 package for AD integration
+# (not enabled in core Redash because of the GPL license conflict)
+ldap3==2.2.4


### PR DESCRIPTION
We need ldap enabled for AD integration - it's not enabled by default due to GPL license conflict